### PR TITLE
update required version of react-relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-runtime": "^5.8.20",
     "react": "^0.14.0-rc1",
     "react-dom": "^0.14.0-rc1",
-    "react-relay": "^0.3.2",
+    "react-relay": "^0.8.1",
     "reindex-js": "^0.3.1"
   },
   "devDependencies": {
@@ -39,7 +39,7 @@
     "babel-core": "^5.8.23",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
-    "babel-relay-plugin": "^0.1.3",
+    "babel-relay-plugin": "^0.8.1",
     "css-loader": "^0.19.0",
     "express": "^4.13.3",
     "react-transform-catch-errors": "^1.0.0",


### PR DESCRIPTION
First off, very cool project! This makes getting started with Relay so much easier.

When going through [the tutorial](https://www.reindex.io/docs/tutorial/adding-mutations/), the mutations weren't working for me. I noticed that the `commitUpdate()` call was failing. That method was introduced in [this commit](https://github.com/facebook/relay/commit/8961271e7) which is only in later versions of `react-relay`.

```
v0.6.1
v0.7.0
v0.7.1
v0.7.2
v0.7.3
v0.8.0
v0.8.1
```
