### PR TITLE
Fixes webpack css loading

### DIFF
--- a/webpack.local.config.js
+++ b/webpack.local.config.js
@@ -47,9 +47,17 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        exclude: /node_modules/,
         loaders: [
           'style-loader',
           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader',
+        ],
+      },
+      {
+        test: /\.css$/,
+        loader: [
+          'style-loader',
+          'css-loader'
         ],
       },
 

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -43,9 +43,18 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract(
+        exclude: /node_modules/,
+        loaders: ExtractTextPlugin.extract(
           'style-loader',
           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
+        ),
+      },
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract(
+          'style-loader',
+          'css-loader',
+          'postcss-loader'
         ),
       },
 


### PR DESCRIPTION
# What is this?

I recently tried out the reindex tutorial in your docs and found all the CSS broken when running production and local builds. Turns out that CSS Module class name strings are getting in the way, but you are not using them. I created a separate CSS loader to work with node_modules/todo-app-css/index.css and left the other loader as is.

CSS now works 🍾 

Let me know if you have any questions and thanks for putting this together. I am currently working on an integration with the GraphQL to work with [Netlify](https://www.netlify.com/) out of the box, which is how I came across this. 

## before fix:

<img width="651" alt="screenshot 2016-12-13 09 56 57" src="https://cloud.githubusercontent.com/assets/5713670/21152333/a96c1354-c11a-11e6-9393-9008b5852a5c.png">

## after fix:

<img width="840" alt="screenshot 2016-12-13 09 55 46" src="https://cloud.githubusercontent.com/assets/5713670/21152292/85940b58-c11a-11e6-83b6-7d8ad0f074d8.png">